### PR TITLE
修复导出脚本和删除脚本的错误

### DIFF
--- a/src/options/Root.vue
+++ b/src/options/Root.vue
@@ -311,7 +311,7 @@ export default {
 			zip.file('config.json', JSON.stringify(config));
 			zip.file('tasks.json', JSON.stringify(this.tasks));
 			let content = await zip.generateAsync({ type: 'blob' })
-			utils.download(content, utils.format(Date.now(), 'YYYY-MM-DD hh:mm:ss.soulsign'))
+			utils.download(content, utils.format(Date.now(), 'YYYY-MM-DD_hh-mm-ss.soulsign'))
 		},
 		async clear() {
 			for (let task of this.tasks) {


### PR DESCRIPTION
由于windows系统的文件名无法含有特殊符号‘:’, 所以修改后，两项功能同时修复（~虽然我只以为能修复一个导出功能~）！