### PR TITLE
设置新建 tab 方式打开网页

### DIFF
--- a/src/backend/scriptbuild.js
+++ b/src/backend/scriptbuild.js
@@ -169,19 +169,14 @@ export default function(task) {
 		open(url, dev, fn) {
 			if (!checkDomain(domains, url)) return Promise.reject(`domain配置不正确`);
 			return new Promise(function(resolve, reject) {
-				chrome.windows.create({left: 0, top: 0, width: window.screen.availWidth, height: window.screen.availHeight, focused: dev},
-					function(w) {
-                        if (!dev) chrome.windows.update(w.id,{state: "minimized",drawAttention: false, focused: false})
-						chrome.tabs.create({url, active: true, windowId: w.id}, function(tab) {
+						chrome.tabs.create({url, active: dev}, function(tab) {
 							Promise.resolve(frameRunner(tab.id, 0, domains, url))
 								.then((x) => x.waitLoaded().then(() => x))
 								.then(fn)
 								.then(resolve, reject)
-								.finally(() => chrome.windows.remove(w.id));
+								.finally(() => chrome.tabs.remove(tab.id));
 						});
-					}
-				);
-			});
+					});
 		},
 	};
 	if (!grant.has("eval")) {


### PR DESCRIPTION
我实验了设置为 tab 方式打开网页，效果上看起来不错。

奇怪的是，我感觉我没有任何对于 ifame 的改变，然而它获取不多阿里云网页的所有 iframe ，造成这个脚本验证失败。

麻烦 @inu1255 大大帮忙看看，是我个人的问题吗？还是说有些地方需要修改。