### PR TITLE
fix(#222): 修复谷歌浏览器在95.0.4638.54版本中扩展报错CSP相关问题

### DIFF
--- a/src/manifest.js
+++ b/src/manifest.js
@@ -36,6 +36,6 @@ module.exports = {
 	    matches: ['<all_urls>'],
 	    all_frames: true
 	}],
-	content_security_policy: "script-src 'self' 'unsafe-eval'; object-src 'self'",
+	content_security_policy: "script-src 'self' 'unsafe-eval'; object-src 'self'; script-src-elem 'self' http://soulsignchrome.inu1255.cn",
 	// web_accessible_resources: ['panel.html', 'js/content.js']
 };


### PR DESCRIPTION
在新版本的谷歌中content_security_policy的权限颗粒度可能变细了，导致报 script-src-elem 权限未声明，因此更新 script-src-elem 权限，并且限定<source url>

fix #222